### PR TITLE
Small Addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# humhub-basic-chat
+# Humhub Basic Chat
 Integrated Chat Module for Humhub v1.0+
 
 This module adds a chat sample chat widget.  Chats older than 24 hours are deleted on a cron.
@@ -8,3 +8,8 @@ Integrates with users to get avatar and username for display.
 Widget now works on spaces, dashboard and profile, thanks to contributions from @WebCrew for styling and making more size agnostic
 
 If you do not want one or more of these, its best to just edit the config and remove the lines for the section you dont want.
+
+## Installation
+1. Download the module and upload it to your modules directory >yourdomain.com>protected>modules
+2. Rename module directory ```basic-chat```
+3. Enable module from >Admin>Modules

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Widget now works on spaces, dashboard and profile, thanks to contributions from 
 
 If you do not want one or more of these, its best to just edit the config and remove the lines for the section you dont want.
 
+If You want to have a lighter themed chat style:
+
+* delete assets/chat.css
+* rename assets/chat.css.bright to chat.css
+* have fun :)
+
 ## Installation
 1. Download the module and upload it to your modules directory >yourdomain.com>protected>modules
 2. Rename module directory ```basic-chat``` (May not be required!)

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ If you do not want one or more of these, its best to just edit the config and re
 
 ## Installation
 1. Download the module and upload it to your modules directory >yourdomain.com>protected>modules
-2. Rename module directory ```basic-chat```
+2. Rename module directory ```basic-chat``` (May not be required!)
 3. Enable module from >Admin>Modules

--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
-    "id": "humhub-chat",
-    "name": "humhub-chat",
+    "id": "basic-chat",
+    "name": "Basic Chat",
     "description": "Adds Chat Functionality.",
     "keywords": ["chat"],
     "version": "0.1.0",


### PR DESCRIPTION
Changes module id to `basic-chat` and name of the module to Basic Chat, as wells as updating the README.md file with installation steps. As for the reasoning behind changing the module id, this is because originally you'd have to change the module folder to `humhub-chat` for it to work (Or at least for me anyways...) I believe that this should be a small fix for this. For the name space of the chat this will give it's intended name, which is `Basic Chat`. :smile:
